### PR TITLE
Improve admin site for users and groups.

### DIFF
--- a/waffle/admin.py
+++ b/waffle/admin.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.admin.widgets import ManyToManyRawIdWidget
+from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
 from waffle.models import Flag, Sample, Switch
@@ -41,13 +43,43 @@ disable_for_all.short_description = _('Disable selected flags for everyone')
 delete_individually.short_description = _('Delete selected')
 
 
+class InformativeManyToManyRawIdWidget(ManyToManyRawIdWidget):
+    """Widget for ManyToManyField to Users.
+
+    Will display the names of the users in a parenthesised list after the
+    input field. This widget works with all models that have a "name" field.
+    """
+    def label_and_url_for_value(self, values):
+        names = []
+        key = self.rel.get_related_field().name
+        for value in values:
+            try:
+                name = self.rel.model._default_manager \
+                    .using(self.db) \
+                    .get(**{key: value})
+                names.append(escape(str(name)))
+            except self.rel.model.DoesNotExist:
+                names.append('<missing>')
+        return "(" + ", ".join(names) + ")", ""
+
+
 class FlagAdmin(BaseAdmin):
     actions = [enable_for_all, disable_for_all, delete_individually]
     list_display = ('name', 'note', 'everyone', 'percent', 'superusers',
                     'staff', 'authenticated', 'languages')
     list_filter = ('everyone', 'superusers', 'staff', 'authenticated')
-    raw_id_fields = ('users', 'groups')
+    raw_id_fields = ('users', )
     ordering = ('-id',)
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        if db_field.name == 'users':
+            kwargs.pop('request', None)
+            kwargs['widget'] = \
+                InformativeManyToManyRawIdWidget(db_field.remote_field,
+                                                 self.admin_site,
+                                                 using=kwargs.get("using"))
+            return db_field.formfield(**kwargs)
+        return super(FlagAdmin, self).formfield_for_dbfield(db_field, **kwargs)
 
 
 def enable_switches(ma, request, qs):

--- a/waffle/tests/test_admin.py
+++ b/waffle/tests/test_admin.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from waffle import get_waffle_flag_model
+from waffle.admin import FlagAdmin, InformativeManyToManyRawIdWidget
+from waffle.tests.base import TestCase
+
+
+class FakeSuperUser:
+    def has_perm(self, perm):
+        return True
+
+
+class FlagAdminTests(TestCase):
+    def setUp(self):
+        self.site = AdminSite()
+
+    def test_informative_widget(self):
+        Flag = get_waffle_flag_model()
+        flag_admin = FlagAdmin(Flag, self.site)
+
+        request = mock.Mock()
+        request.has_perm = lambda self, perm: True
+        form = flag_admin.get_form(request)()
+        user_widget = form.fields["users"].widget
+
+        self.assertIsInstance(user_widget, InformativeManyToManyRawIdWidget)
+        user1 = get_user_model().objects.create(username="test1")
+        user2 = get_user_model().objects.create(username="test2")
+        self.assertIn("(test1, test2)",
+                      user_widget.render("users", [user1.pk, user2.pk]))


### PR DESCRIPTION
- Use the regular list widget for groups (there are likely not
  that many, so performance should not be an issue).
- Keep the users as a raw_id field, but display the selected users
  after the input box in a parenthesized list.